### PR TITLE
Fixed detect-scheme.sh typo

### DIFF
--- a/install_station/partition.py
+++ b/install_station/partition.py
@@ -129,7 +129,7 @@ def get_scheme(disk: str) -> str:
         str: Partition scheme ('GPT', 'MBR', or empty if none)
     """
     scheme_output = Popen(
-        f"{query}/detect-sheme.sh {disk}",
+        f"{query}/detect-scheme.sh {disk}",
         shell=True,
         stdin=PIPE,
         stdout=PIPE,

--- a/src/backend-query/detect-scheme.sh
+++ b/src/backend-query/detect-scheme.sh
@@ -31,9 +31,9 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-# /usr/local/etc/install-station/detect-sheme.sh v 0.1 Wed May  1 20:31:52 ADT 2013 Eric Turgeon
+# /usr/local/etc/install-station/detect-scheme.sh v 0.1 Wed May  1 20:31:52 ADT 2013 Eric Turgeon
 #
-# Detect a disk sheme and display them.
+# Detect a disk scheme and display them.
 #
 
 


### PR DESCRIPTION
## Summary by Sourcery

Correct the typo in the disk detection script name and its references

Bug Fixes:
- Fix script header comment to use 'detect-scheme.sh' instead of 'detect-sheme.sh'
- Update Python call to reference 'detect-scheme.sh' correctly