### PR TITLE
Clean `create_cfg.py` updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Install Station
 ===
-It is a strip down version of install-station and it is the new installer for GhostBSD.
+Install Station is the streamlined installer for GhostBSD.
 
-Install Station only edit disk, partition and will install GhostBSD. Users and system setup will be done with at the first boot after installation with Setup Station.
+Install Station handles disk editing, partitioning, and OS installation. User configuration and system setup are performed at first boot after installation with Setup Station.
 
 ## Managing Translations
 To create a translation file.


### PR DESCRIPTION
- Trim unnecessary trailing whitespaces
- Simplify logic in error and disk partition checks
- Replace ambiguous return with a more Pythonic `not errors`
- Enhance IOError handling for clarity
- Update `README.md` for clearer installer purpose and flow

## Summary by Sourcery

Improve configuration validation clarity in the installer and refresh installer documentation wording.

Enhancements:
- Use a more idiomatic boolean check in configuration validation and simplify partition line filtering.
- Clarify IOError propagation when writing the installation configuration file.

Documentation:
- Clarify the purpose of Install Station and its relationship with Setup Station in the README.