### PR TITLE
Fix .xinitrc path and improve UI visibility in installation

### DIFF
--- a/install_station/install.py
+++ b/install_station/install.py
@@ -112,6 +112,7 @@ class InstallWindow:
         label2.set_line_wrap(True)
         # label2.set_max_width_chars(10)
         label2.set_alignment(0.0, 0.2)
+        label2.show()
         hbox2 = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, homogeneous=False, spacing=0, name="TransBox")
         hbox2.show()
         hbox.pack_start(hbox2, True, True, 0)

--- a/install_station/interface_controller.py
+++ b/install_station/interface_controller.py
@@ -208,10 +208,10 @@ class Interface:
                         InstallationData.keyboard_variant,
                         InstallationData.keyboard_model_code
                     )
-                with open('/usr/home/ghostbsd/.xinitrc', 'w') as xinitrc:
+                with open('/home/ghostbsd/.xinitrc', 'w') as xinitrc:
                     xinitrc.writelines('gsettings set org.mate.SettingsDaemon.plugins.housekeeping active true &\n')
-                xinitrc.writelines('gsettings set org.mate.screensaver lock-enabled false &\n')
-                xinitrc.writelines('exec ck-launch-session mate-session\n')
+                    xinitrc.writelines('gsettings set org.mate.screensaver lock-enabled false &\n')
+                    xinitrc.writelines('exec ck-launch-session mate-session\n')
                 Gtk.main_quit()
         elif page == 4:
             Button.show_back()


### PR DESCRIPTION
- Change .xinitrc path from `/usr/home/ghostbsd/` to `/home/ghostbsd/` for correct FreeBSD home directory handling
- Fix indentation of .xinitrc writelines() calls to be inside the file context manager (prevents potential file write errors)
- Add explicit label2.show() call in InstallWindow to ensure progress label visibility during installation

These changes ensure proper file handling in "Try Live" mode and improve installation UI feedback reliability.

## Summary by Sourcery

Update installation behavior to use the correct GhostBSD home directory for .xinitrc creation and ensure the installation progress label is always visible.

Bug Fixes:
- Correct the .xinitrc path to use /home/ghostbsd and ensure all write operations occur within the file context manager.

Enhancements:
- Explicitly show the secondary installation label to improve progress visibility during installation.